### PR TITLE
fix: bump consola to 3.x to align with other nuxt 2 packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "consola": "^2.15.0",
+    "consola": "^3.2.3",
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,4 +1,4 @@
-import consola from 'consola'
+import { consola } from 'consola'
 
 export const reportAndThrowError = (msg) => {
   report(msg)

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -1,6 +1,6 @@
 import path from 'path'
 import { spy } from 'sinon'
-import consola from 'consola'
+import { consola } from 'consola'
 
 export const spyOnConsola = (t) => {
   t.context.consola = spy()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,10 +2172,10 @@ concordance@^5.0.4:
     semver "^7.3.2"
     well-known-symbols "^2.0.0"
 
-consola@^2.15.0:
-  version "2.15.3"
-  resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
-  integrity sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==
+consola@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/consola/-/consola-3.2.3.tgz#0741857aa88cfa0d6fd53f1cff0375136e98502f"
+  integrity sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==
 
 conventional-changelog-angular@^5.0.11, conventional-changelog-angular@^5.0.12:
   version "5.0.13"


### PR DESCRIPTION
Addressing the https://github.com/nuxt/nuxt/issues/24343 issue which is about outdated `consola` being used in a couple of Nuxt 2 packages.